### PR TITLE
Explicitly build libraries as STATIC

### DIFF
--- a/src/imlib/CMakeLists.txt
+++ b/src/imlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(imlib
+add_library(imlib STATIC
     filter.cpp filter.h
     image.cpp image.h
     transimage.cpp transimage.h

--- a/src/lisp/CMakeLists.txt
+++ b/src/lisp/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(lisp
+add_library(lisp STATIC
     lisp.cpp lisp.h
     lisp_opt.cpp lisp_opt.h
     lisp_gc.cpp lisp_gc.h

--- a/src/net/CMakeLists.txt
+++ b/src/net/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(net
+add_library(net STATIC
     gserver.cpp gserver.h
     gclient.cpp gclient.h
     fileman.cpp fileman.h

--- a/src/sdlport/CMakeLists.txt
+++ b/src/sdlport/CMakeLists.txt
@@ -1,6 +1,6 @@
 #DEFS = @DEFS@
 
-add_library(sdlport
+add_library(sdlport STATIC
     video.cpp
     event.cpp
     sound.cpp sound.h


### PR DESCRIPTION
Some distributions default to building libraries under CMake as shared, which breaks in this particular case so be explicit.