### PR TITLE
Small bugfixes in built-in edtor

### DIFF
--- a/src/dev.cpp
+++ b/src/dev.cpp
@@ -776,7 +776,7 @@ void dev_controll::toggle_bgw()
     /* FIXME: previous code had 1 instead of 0, investigate */
     tile_picker *f_tp = new tile_picker(0, 0, DEV_BG_PICKER, SPEC_BACKTILE,
                                         bg_scale, maxh, bg_w, NULL);
-    forew = wm->CreateWindow(ivec2(prop->getd("back x", -30),
+    backw = wm->CreateWindow(ivec2(prop->getd("back x", -30),
                                    prop->getd("back y", 0)),
                              ivec2(-1), f_tp,symbol_str("l_bg"));
 }

--- a/src/devsel.cpp
+++ b/src/devsel.cpp
@@ -126,7 +126,7 @@ void tile_picker::scroll_event(int newx, image *screen)
       {
         if (backtiles[i]<0) blank=1;
         else
-          scale_put(the_game->get_bg(i)->im,screen,m_pos.x,m_pos.y,xw,ya);
+          scale_put(the_game->get_bg(i)->im,screen,xyo.x,xyo.y,xw,ya);
 
       } break;
       case SPEC_CHARACTER :
@@ -138,7 +138,7 @@ void tile_picker::scroll_event(int newx, image *screen)
       } else blank=1;
 
       if (i==c)
-        screen->Rectangle(m_pos, m_pos + ivec2(xw - 1, ya - 1),
+        screen->Rectangle(xyo, xyo + ivec2(xw - 1, ya - 1),
                           wm->bright_color());
 
 


### PR DESCRIPTION
Hello. As for many others here, Abuse was a formative 2D-platform experience for me, and after so many years, I'm happy to revisit it, now as a contributor. 
First thing I've done after building the port is ran a build-in editor, and realised that there were a few UI things broken there.

Here is the screenshot, comparing editor behaviour of original build running in DOSBox vs current master of SDL port. 
![image](https://user-images.githubusercontent.com/86923754/125311762-55164d80-e33c-11eb-9b9d-bf576d8d3956.png)
This PR fixes this inconsistency. 
I understand, that editor functionality is not the main focus of this port, but imo, it would still be nice to keep it in shape. There are other issues there, like play mode running at wrong speed, but to keep the PR reviewing work simpler, I would approach it gradually. 

- Fixes background tile picker display. Tiles are now drawn with the proper vertical offset, incremented during for-loop
- Fixed background tile picker closing. When created, the window reference was wrongly set to foreground tile picker

Thank you 