### PR TITLE
Fixed framerate getting unbound when switching to "Play" mode in editor

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -562,7 +562,6 @@ int need_delay = 1;
 
 void Game::dev_scroll()
 {
-  need_delay = 0;
   if(dev)
   {
     int xmargin, ymargin;
@@ -598,7 +597,6 @@ void Game::dev_scroll()
 
     if(xs || ys)
     {
-      need_delay = 1;
       if(dev & MAP_MODE)
       {
     map_xoff += xs / 2;


### PR DESCRIPTION
When switching to `Play` mode by pressing `Tab` in Abuse editor, the framerate gets unbound, making it unplayably fast and eating the CPU cycles. This behaviour reveals itself on MacOS and Linux builds (most probably on Windows too, but it was not tested).

The issue happens to be, because `dev_scroll()` method is unsetting the `need_delay` flag. I suppose this was done to eliminate any possible delays when performing editor actions, however it does not seem to be any of those bounded by game ticks. Removing this flag manipulation fixed the issue and did not affect scrolling or GUI speed of the editor. 

Steps to reproduce the issue:
1. `./abuse -edit`
2. Press Tab
3. See that game runs at enormous speed and CPU is burning

Thank you