### PR TITLE
Fixed game crashing on MacOS when pressing Mac's CMD(⌘) button

### DIFF
--- a/src/sdlport/event.cpp
+++ b/src/sdlport/event.cpp
@@ -254,6 +254,8 @@ void EventHandler::SysEvent(Event &ev)
         case SDLK_RIGHT:        ev.key = JK_RIGHT; break;
         case SDLK_LCTRL:        ev.key = JK_CTRL_L; break;
         case SDLK_RCTRL:        ev.key = JK_CTRL_R; break;
+        case SDLK_LGUI:         ev.key = JK_COMMAND; break;
+        case SDLK_RGUI:         ev.key = JK_COMMAND; break;
         case SDLK_LALT:         ev.key = JK_ALT_L; break;
         case SDLK_RALT:         ev.key = JK_ALT_R; break;
         case SDLK_LSHIFT:       ev.key = JK_SHIFT_L; break;


### PR DESCRIPTION
When pressing the cmd-key, game crashes, even if no action is mapped to it. 
The crash happens in `/imlib/jwindow.cpp`: 
```cpp
void WindowManager::get_event(Event &ev)
{
  Get(ev);

  if (ev.type==EV_KEY)
    key_state[ev.key]=1;   // ev.key is out of array bounds
  ...
}
```
The proposed solution is to use `SDLK_LGUI` and `SDLK_LGUI` bindings for this mac-specific key from SDL library and map then to standard keyboard layout Abuse input routine can operate (`keys.h` file). 
Unfortunately, it seems to be no direct mapping of Mac CMD to that layout, taking in account that they are also mirrored, so I mapped them both to `JK_COMMAND` (I do not even remember seeing it on the standard DOS keyboard)
 
This can be altered at maintainer's discretion.  
Thank you. 